### PR TITLE
Fetch javascript libraries over https

### DIFF
--- a/flask_blogging/templates/blogging/base.html
+++ b/flask_blogging/templates/blogging/base.html
@@ -61,8 +61,8 @@
      </div>
     {% include "blogging/analytics.html" %}
     {% block js %}
-    <script type="text/javascript" src="http://code.jquery.com/jquery-2.1.4.min.js"></script>
-    <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
     <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script type="text/x-mathjax-config">
           MathJax.Hub.Config({


### PR DESCRIPTION
The javascript libraries JQuery and MathJax were requested over HTTP instead of HTTPS.